### PR TITLE
Blocking accept() -> epoll() based event loop

### DIFF
--- a/c-server/src/common.h
+++ b/c-server/src/common.h
@@ -14,13 +14,18 @@
 #include <string.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <errno.h>
+#include <limits.h>
+
+#include <linux/limits.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <netdb.h>
+
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <linux/limits.h>
-#include <limits.h>
-#include <errno.h>
-#include <netdb.h>
+#include <sys/epoll.h>
 
 #define str(x) #x
 #define xstr(x) str(x)
@@ -28,6 +33,7 @@
 #define MAX_BUFFER_SIZE 8192 // 8 KB
 #define MAX_HEADERS 50
 #define MAX_BACKENDS 16
+#define MAX_EPOLL_EVENTS 10
 #define HTTPRESPONSE_CAPACITY 1024
 
 #define DEFAULT_CONFIG_PATH "/home/voidp/Projects/samandar/1lang1server/cserver"

--- a/c-server/src/http/parsers.c
+++ b/c-server/src/http/parsers.c
@@ -155,3 +155,24 @@ void parse_body(HTTPRequest *req, char *raw_body, int content_length)
     req->body[content_length] = '\0';
     req->body_length          = content_length;
 }
+
+const char *get_mime_type(const char *filepath)
+{
+    const char *ext = strrchr(filepath, '.');
+    if (!ext) return "application/octet-stream";
+
+    ext++; // skip the dot
+    if (strcmp(ext, "html") == 0) return "text/html";
+    if (strcmp(ext, "css") == 0) return "text/css";
+    if (strcmp(ext, "js") == 0) return "application/javascript";
+    if (strcmp(ext, "png") == 0) return "image/png";
+    if (strcmp(ext, "jpg") == 0) return "image/jpeg";
+    if (strcmp(ext, "jpeg") == 0) return "image/jpeg";
+    if (strcmp(ext, "gif") == 0) return "image/gif";
+    if (strcmp(ext, "svg") == 0) return "image/svg+xml";
+    if (strcmp(ext, "ico") == 0) return "image/x-icon";
+    if (strcmp(ext, "json") == 0) return "application/json";
+    if (strcmp(ext, "pdf") == 0) return "application/pdf";
+
+    return "application/octet-stream";
+}

--- a/c-server/src/http/parsers.h
+++ b/c-server/src/http/parsers.h
@@ -13,3 +13,4 @@ HTTPRequest *parse_http_request(char *request_str);
 int parse_request_line(HTTPRequest *request_ptr, char *request_line);
 void parse_headers(HTTPRequest *request_ptr, char *headers);
 void parse_body(HTTPRequest *request_ptr, char *body, int content_length);
+const char *get_mime_type(const char *filepath);

--- a/c-server/src/http/response.h
+++ b/c-server/src/http/response.h
@@ -20,6 +20,7 @@ typedef struct
     int header_count;
     char *body;
     int body_length;
+    char *content_type;
 } HTTPResponse;
 
 HTTPResponse *httpresponse_constructor();
@@ -28,6 +29,7 @@ void httpresponse_free(HTTPResponse *httpresponse_ptr);
 int httpresponse_add_header(HTTPResponse *res, const char *key, const char *value);
 char *httpresponse_serialize(HTTPResponse *res, size_t *out_len);
 
-HTTPResponse *response_builder(int status_code, char *phrase, char *body);
+HTTPResponse *response_builder(int status_code, const char *phrase, const char *body,
+                               size_t body_length, const char *content_type);
 
 #endif

--- a/c-server/src/http/server.c
+++ b/c-server/src/http/server.c
@@ -27,6 +27,8 @@
  */
 int launch(HTTPServer *self)
 {
+    char s[INET6_ADDRSTRLEN];
+
     if (bind(self->server->socket, (struct sockaddr *)&self->server->address,
              sizeof(self->server->address)) < 0)
     {
@@ -38,34 +40,116 @@ int launch(HTTPServer *self)
         return SOCKET_LISTEN_ERROR;
     }
 
+    int epoll_fd = epoll_create1(0);
+    if (epoll_fd == -1)
+    {
+        fprintf(stderr, "[ERROR] epoll_create1() call");
+        exit(1);
+    }
+
+    struct epoll_event ev, events[MAX_EPOLL_EVENTS];
+    ev.events  = EPOLLIN;
+    ev.data.fd = self->server->socket;
+    if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, self->server->socket, &ev) == -1)
+    {
+        perror("[ERROR] Failed to add server socket to epoll event loop.");
+        exit(1);
+    }
+
     printf("\033[32m===== Waiting for connections on port %d =====\033[0m\n", self->server->port);
 
     while (1)
     {
-        char buffer[MAX_BUFFER_SIZE];
+        char buff[MAX_BUFFER_SIZE];
         int address_length = sizeof(self->server->address);
-        int new_socket     = accept(self->server->socket, (struct sockaddr *)&self->server->address,
-                                    (socklen_t *)&address_length);
-        recv(new_socket, buffer, MAX_BUFFER_SIZE, 0);
-        printf("%s\n", buffer);
 
-        HTTPRequest *httprequest_ptr = parse_http_request(buffer);
+        int n_ready = epoll_wait(epoll_fd, events, MAX_EPOLL_EVENTS, -1);
+        if (n_ready == -1)
+        {
+            perror("[ERROR] Failed to wait for epoll events.");
+            continue;
+        }
 
-        HTTPResponse *httpresponse_ptr = request_handler(httprequest_ptr);
+        for (int i = 0; i < n_ready; i++)
+        {
+            if (events[i].data.fd == self->server->socket)
+            {
+                // Accept a new connection
+                int client_fd =
+                    accept(self->server->socket, (struct sockaddr *)&self->server->address,
+                           (socklen_t *)&address_length);
+                if (client_fd == -1)
+                {
+                    perror("[ERROR] Error while accepting a new connection");
+                    continue;
+                }
 
-        char *response = httpresponse_serialize(httpresponse_ptr, NULL);
+                // Make socket nonblocking
+                int flags = fcntl(client_fd, F_GETFL, 0);
+                if (flags == -1) return -1;
+                fcntl(client_fd, F_SETFL, flags | O_NONBLOCK);
 
-        // caller of the request_handler is responsible for freeing the memory
-        httpresponse_free(httpresponse_ptr);
+                ev.events  = EPOLLIN | EPOLLOUT;
+                ev.data.fd = client_fd;
+                if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, client_fd, &ev) == -1)
+                {
+                    perror("[ERROR] Error while responding to the client socket: ");
+                    continue;
+                }
 
-        printf("===== Response:\n%s", response);
+                printf("[INFO] Client FD: %d, Assigned FD: %d\n", client_fd, ev.data.fd);
 
-        send(new_socket, response, strlen(response), 0);
+                inet_ntop(self->server->address.sin_family,
+                          (struct sockaddr *)&self->server->address, s, sizeof(s));
+                printf("[INFO] Got connection from %s\n", s);
+            }
+            else
+            {
+                // Read from client socket and handle accordingly
+                int bytes_read = recv(events[i].data.fd, buff, MAX_BUFFER_SIZE, 0);
+                if (bytes_read <= 0)
+                {
+                    if (errno == EAGAIN || errno == EWOULDBLOCK)
+                    {
+                        // Nothing to read now — try again later
+                        continue;
+                    }
+                    if (bytes_read < 0) perror("[ERROR] Error while reading from client socket: ");
+                    close(events[i].data.fd);
+                    printf("[INFO] Connection closed.\n");
+                }
+                else
+                {
+                    printf("[INFO] Received: %s\nBytes read: %d\n", buff, bytes_read);
+                    HTTPRequest *httprequest_ptr   = parse_http_request(buff);
+                    HTTPResponse *httpresponse_ptr = request_handler(httprequest_ptr);
 
-        // Caller owned malloced buffer, so frees it now
-        free(response);
+                    char *response   = httpresponse_serialize(httpresponse_ptr, NULL);
+                    int response_len = strlen(response);
 
-        close(new_socket);
+                    // caller of the request_handler is responsible for freeing the memory
+                    httpresponse_free(httpresponse_ptr);
+
+                    printf("===== Response:\n%s\n\n", response);
+
+                    int total_sent = 0;
+                    while (total_sent < response_len)
+                    {
+                        int bytes_sent = send(events[i].data.fd, response + total_sent,
+                                              response_len - total_sent, 0);
+                        if (bytes_sent <= 0)
+                        {
+                            perror("[ERROR] Error while sending response to client socket: ");
+                            break;
+                        }
+                        total_sent += bytes_sent;
+                    }
+
+                    // Caller owned malloced buffer, so frees it now
+                    free(response);
+                }
+            }
+        }
     }
 }
 
@@ -135,6 +219,8 @@ HTTPResponse *request_handler(HTTPRequest *request_ptr)
             size_t filesize = st.st_size;
 
             char *buffer = malloc(filesize);
+            memset(buffer, 0, filesize);
+
             if (!buffer)
             {
                 close(fd);
@@ -142,9 +228,23 @@ HTTPResponse *request_handler(HTTPRequest *request_ptr)
                 return response_builder(500, "Internal Server Error", response_buffer,
                                         sizeof(response_buffer), "text/html");
             }
-            size_t bytes_read = read(fd, buffer, sizeof(buffer));
-            printf("Read %zu bytes\nActual filesize: %zu\n", bytes_read, filesize);
-            if (bytes_read != filesize)
+
+            size_t total_read = 0;
+            while (total_read < filesize)
+            {
+                size_t bytes = read(fd, buffer + total_read, filesize - total_read);
+                if (bytes <= 0)
+                {
+                    free(buffer);
+                    char response_buffer[] = "<h1>Failed to read file</h1>";
+                    return response_builder(500, "Internal Server Error", response_buffer,
+                                            sizeof(response_buffer), "text/html");
+                }
+                total_read += bytes;
+            }
+
+            printf("Read %zu bytes\nActual filesize: %zu\n", total_read, filesize);
+            if (total_read != filesize)
             {
                 free(buffer);
                 char response_buffer[] = "<h1>Failed to read file</h1>";
@@ -274,6 +374,16 @@ int connect_to_backend(const char *host, const char *port)
     return sock;
 }
 
+void *get_in_addr(struct sockaddr *sa)
+{
+    if (sa->sa_family == AF_INET)
+    {
+        return &(((struct sockaddr_in *)sa)->sin_addr);
+    }
+
+    return &(((struct sockaddr_in6 *)sa)->sin6_addr);
+}
+
 /**
  * @brief   Constructor for the HTTPServer struct, setting up a server and HTTP
  *          request handler.
@@ -309,5 +419,6 @@ void httpserver_destructor(HTTPServer *httpserver_ptr)
     {
         server_destructor(httpserver_ptr->server);
     }
+    free(httpserver_ptr->static_dir);
     free(httpserver_ptr);
 }


### PR DESCRIPTION
We have successfully changed the blocking accept() only loop to libevent's epoll()-based asynchronous event loop. From now on, we hope at least, our web server can work with huge loads efficiently.

- I should test and benchmark it soon anyway :))